### PR TITLE
feat(front): mostrar vencedor do confronto

### DIFF
--- a/src/app/core/models/jogo.model.ts
+++ b/src/app/core/models/jogo.model.ts
@@ -10,6 +10,18 @@ export interface MatchResult {
   idJogo: number;
 }
 
+export type MatchScore = {
+  timeId: number;
+  pontos: number;
+};
+
+export type MatchWinnerResult = {
+  jogoId: number;
+  empate: boolean;
+  vencedorTimeId: number | null;
+  placares: MatchScore[];
+};
+
 export interface JogoComDetalhes extends Jogo {
   resultados?: MatchResult[];
 }

--- a/src/app/core/services/jogo.service.ts
+++ b/src/app/core/services/jogo.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
-import { Jogo, MatchResult } from '../models/jogo.model';
+import { Jogo, MatchResult, MatchWinnerResult } from '../models/jogo.model';
 
 export type RegistrarResultadoConfrontoRequest = {
   timeId: number;
@@ -31,6 +31,10 @@ export class JogoService {
 
   getJogoResultados(jogoId: number): Observable<MatchResult[]> {
     return this.http.get<MatchResult[]>(`${this.apiUrl}/confrontos/${jogoId}/results`);
+  }
+
+  getJogoWinner(jogoId: number): Observable<MatchWinnerResult> {
+    return this.http.get<MatchWinnerResult>(`${this.apiUrl}/confrontos/${jogoId}/winner`);
   }
 
   registrarResultadoConfronto(

--- a/src/app/features/jogos/jogo-detail/jogo-detail.component.html
+++ b/src/app/features/jogos/jogo-detail/jogo-detail.component.html
@@ -34,6 +34,49 @@
       </div>
     </div>
 
+    <div class="card vencedor">
+      <h3>Vencedor</h3>
+
+      <ng-container [ngSwitch]="winnerState.status">
+        <div *ngSwitchCase="'loading'" class="winner-state">
+          <span class="mini-spinner" aria-hidden="true"></span>
+          <p>Carregando vencedor...</p>
+        </div>
+
+        <div *ngSwitchCase="'error'" class="winner-state error">
+          <div class="error-icon">⚠️</div>
+          <p>{{ winnerErrorMessage }}</p>
+        </div>
+
+        <div *ngSwitchCase="'empty'" class="winner-state empty">
+          <div class="empty-icon">—</div>
+          <p>{{ winnerEmptyMessage }}</p>
+        </div>
+
+        <ng-container *ngSwitchCase="'ready'">
+          <div class="winner-ready" *ngIf="winnerReady as winner">
+            <div class="winner-badge" [class.draw]="winner.empate">
+              <span class="label">{{ winner.empate ? 'Empate' : 'Vencedor' }}</span>
+              <span class="value">
+                {{ winner.empate ? 'Sem vencedor definido' : ('Time #' + winner.vencedorTimeId) }}
+              </span>
+            </div>
+
+            <div class="placares" *ngIf="winner.placares.length > 0">
+              <div
+                class="placar-row"
+                *ngFor="let placar of winner.placares"
+                [class.is-winner]="!winner.empate && placar.timeId === winner.vencedorTimeId"
+              >
+                <span class="team">Time #{{ placar.timeId }}</span>
+                <span class="points">{{ placar.pontos }} pts</span>
+              </div>
+            </div>
+          </div>
+        </ng-container>
+      </ng-container>
+    </div>
+
     <div class="card resultados">
       <h3>Resultados do Confronto</h3>
       <div *ngIf="resultados.length === 0" class="empty-state">

--- a/src/app/features/jogos/jogo-detail/jogo-detail.component.scss
+++ b/src/app/features/jogos/jogo-detail/jogo-detail.component.scss
@@ -262,15 +262,75 @@
         align-items: center;
         gap: 0.625rem;
       }
+    }
+  }
+}
 
-      .mini-spinner {
-        width: 16px;
-        height: 16px;
-        border-radius: 50%;
-        border: 2px solid rgba(255, 255, 255, 0.15);
-        border-top-color: rgba(255, 255, 255, 0.95);
-        animation: spin 800ms linear infinite;
-      }
+.mini-spinner {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.15);
+  border-top-color: rgba(255, 255, 255, 0.95);
+  animation: spin 800ms linear infinite;
+}
+
+.vencedor {
+  .winner-state {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.95rem 1.05rem;
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.02);
+    color: rgba(255, 255, 255, 0.8);
+
+    &.error {
+      background: rgba(239, 68, 68, 0.08);
+      color: #fca5a5;
+    }
+
+    p {
+      margin: 0;
+    }
+  }
+
+  .winner-badge {
+    display: grid;
+    padding: 1rem 1.1rem;
+    border-radius: 18px;
+    background: rgba(16, 185, 129, 0.08);
+
+    &.draw {
+      background: rgba(255, 193, 7, 0.08);
+    }
+
+    .label {
+      color: rgba(255, 255, 255, 0.65);
+      text-transform: uppercase;
+      letter-spacing: 1.2px;
+      font-size: 0.75rem;
+      font-weight: 700;
+    }
+
+    .value {
+      font-size: 1.25rem;
+      font-weight: 900;
+      line-height: 1.15;
+      color: rgba(255, 255, 255, 0.95);
+    }
+  }
+
+  .placar-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.85rem 1rem;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.02);
+
+    &.is-winner {
+      background: rgba(16, 185, 129, 0.08);
     }
   }
 }

--- a/src/app/features/jogos/jogo-detail/jogo-detail.component.ts
+++ b/src/app/features/jogos/jogo-detail/jogo-detail.component.ts
@@ -11,7 +11,7 @@ import {
   Validators
 } from '@angular/forms';
 import { JogoService } from '../../../core/services/jogo.service';
-import { Jogo, MatchResult } from '../../../core/models/jogo.model';
+import { Jogo, MatchResult, MatchWinnerResult } from '../../../core/models/jogo.model';
 import { forkJoin, of, switchMap } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
@@ -25,6 +25,12 @@ type ResultadoFormGroup = FormGroup<{
   timeId: FormControl<number | null>;
   pontos: FormControl<number | null>;
 }>;
+
+type WinnerState =
+  | { status: 'loading' }
+  | { status: 'empty'; message: string }
+  | { status: 'ready'; data: MatchWinnerResult }
+  | { status: 'error'; message: string };
 
 const integerValidator = (): ValidatorFn => {
   return (control: AbstractControl): ValidationErrors | null => {
@@ -49,8 +55,21 @@ export class JogoDetailComponent implements OnInit {
   loading = true;
   error: string | null = null;
   registerState: RegisterState = { status: 'idle' };
+  winnerState: WinnerState = { status: 'loading' };
   resultadoForm: ResultadoFormGroup;
   private jogoId: number | null = null;
+
+  get winnerReady(): MatchWinnerResult | null {
+    return this.winnerState.status === 'ready' ? this.winnerState.data : null;
+  }
+
+  get winnerEmptyMessage(): string | null {
+    return this.winnerState.status === 'empty' ? this.winnerState.message : null;
+  }
+
+  get winnerErrorMessage(): string | null {
+    return this.winnerState.status === 'error' ? this.winnerState.message : null;
+  }
 
   constructor(
     private route: ActivatedRoute,
@@ -83,6 +102,7 @@ export class JogoDetailComponent implements OnInit {
 
     this.jogoId = id;
     this.registerState = { status: 'idle' };
+    this.winnerState = { status: 'loading' };
 
     forkJoin({
       jogo: this.jogoService.getJogoById(id).pipe(
@@ -101,10 +121,37 @@ export class JogoDetailComponent implements OnInit {
           console.error('Erro ao carregar resultados:', err);
           return of([]);
         })
+      ),
+      winnerState: this.jogoService.getJogoWinner(id).pipe(
+        switchMap((winner) => {
+          if (winner.empate) {
+            return of({ status: 'ready', data: winner } as const);
+          }
+          if (winner.vencedorTimeId === null) {
+            return of({
+              status: 'empty',
+              message: 'Vencedor ainda não definido.'
+            } as const);
+          }
+          return of({ status: 'ready', data: winner } as const);
+        }),
+        catchError(err => {
+          if (err?.status === 404) {
+            return of({
+              status: 'empty',
+              message: 'Vencedor ainda não definido.'
+            } as const);
+          }
+          return of({
+            status: 'error',
+            message: 'Erro ao carregar o vencedor.'
+          } as const);
+        })
       )
-    }).subscribe(({ jogo, resultados }) => {
+    }).subscribe(({ jogo, resultados, winnerState }) => {
       this.jogo = jogo;
       this.resultados = resultados;
+      this.winnerState = winnerState;
       this.loading = false;
     });
   }
@@ -133,10 +180,43 @@ export class JogoDetailComponent implements OnInit {
 
     this.jogoService
       .registrarResultadoConfronto(this.jogoId, { timeId, pontos })
-      .pipe(switchMap(() => this.jogoService.getJogoResultados(this.jogoId as number)))
+      .pipe(
+        switchMap(() =>
+          forkJoin({
+            resultados: this.jogoService.getJogoResultados(this.jogoId as number),
+            winnerState: this.jogoService.getJogoWinner(this.jogoId as number).pipe(
+              switchMap((winner) => {
+                if (winner.empate) {
+                  return of({ status: 'ready', data: winner } as const);
+                }
+                if (winner.vencedorTimeId === null) {
+                  return of({
+                    status: 'empty',
+                    message: 'Vencedor ainda não definido.'
+                  } as const);
+                }
+                return of({ status: 'ready', data: winner } as const);
+              }),
+              catchError(err => {
+                if (err?.status === 404) {
+                  return of({
+                    status: 'empty',
+                    message: 'Vencedor ainda não definido.'
+                  } as const);
+                }
+                return of({
+                  status: 'error',
+                  message: 'Erro ao carregar o vencedor.'
+                } as const);
+              })
+            )
+          })
+        )
+      )
       .subscribe({
-        next: (resultadosAtualizados) => {
-          this.resultados = resultadosAtualizados;
+        next: ({ resultados, winnerState }) => {
+          this.resultados = resultados;
+          this.winnerState = winnerState;
           this.registerState = {
             status: 'success',
             message: 'Resultado registrado com sucesso.'


### PR DESCRIPTION
## O que mudou
- Adicionado card Vencedor no detalhe do jogo (/jogos/:id) com estados de loading/erro/vazio e destaque visual do time vencedor.
- Atualizado o serviço de jogos para consumir o endpoint de vencedor.
- Adicionadas tipagens do payload do endpoint /confrontos/{jogoId}/winner.

## Por que mudou
- src/app/core/models/jogo.model.ts: inclui tipos (MatchWinnerResult/MatchScore) para garantir tipagem forte no consumo do endpoint.
- src/app/core/services/jogo.service.ts: adiciona getJogoWinner() para centralizar chamadas HTTP e evitar duplicação.
- src/app/features/jogos/jogo-detail/jogo-detail.component.ts: carrega o vencedor junto com jogo/resultados e atualiza o card após registrar um resultado, mantendo a UI consistente.
- src/app/features/jogos/jogo-detail/jogo-detail.component.html + .scss: renderiza o card do vencedor com visual premium e sem quebrar a página quando 404/sem vencedor.

## Contexto
Closes #8