### PR TITLE
feat(front): listar times

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -27,6 +27,16 @@ export const routes: Routes = [
     loadComponent: () => import('./features/jogos/jogo-detail/jogo-detail.component').then(m => m.JogoDetailComponent)
   },
   {
+    path: 'times/:id',
+    canMatch: [authGuard],
+    loadComponent: () => import('./features/times/time-detail-stub/time-detail-stub.component').then(m => m.TimeDetailStubComponent)
+  },
+  {
+    path: 'times',
+    canMatch: [authGuard],
+    loadComponent: () => import('./features/times/list-times/list-times.component').then(m => m.ListTimesComponent)
+  },
+  {
     path: '',
     redirectTo: 'jogos',
     pathMatch: 'full'

--- a/src/app/core/models/time.model.ts
+++ b/src/app/core/models/time.model.ts
@@ -1,0 +1,5 @@
+export type Time = {
+  id: number;
+  nome?: string;
+  sigla?: string;
+};

--- a/src/app/core/services/times.service.ts
+++ b/src/app/core/services/times.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { Time } from '../models/time.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TimesService {
+  private readonly apiUrl = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  getTimes(): Observable<Time[]> {
+    return this.http.get<Time[]>(`${this.apiUrl}/times`);
+  }
+}

--- a/src/app/features/times/list-times/list-times.component.html
+++ b/src/app/features/times/list-times/list-times.component.html
@@ -1,0 +1,32 @@
+<div class="times-page">
+  <div class="header">
+    <h1>Times</h1>
+  </div>
+
+  <div *ngIf="status === 'loading'" class="state loading" role="status" aria-live="polite">
+    <span class="spinner" aria-hidden="true"></span>
+    <p>Carregando times...</p>
+  </div>
+
+  <div *ngIf="status === 'error'" class="state error" role="alert">
+    <p>{{ errorMessage }}</p>
+    <button type="button" class="btn-primary" (click)="loadTimes()">Tentar novamente</button>
+  </div>
+
+  <div *ngIf="status === 'empty'" class="state empty" role="status">
+    <p>Nenhum time encontrado.</p>
+  </div>
+
+  <div *ngIf="status === 'ready'" class="grid">
+    <div class="card" *ngFor="let time of times; trackBy: trackByTimeId">
+      <div class="card-main">
+        <div class="title">
+          <span class="name">{{ time.nome || ('Time #' + time.id) }}</span>
+          <span class="sigla" *ngIf="time.sigla">{{ time.sigla }}</span>
+        </div>
+        <div class="meta">ID: {{ time.id }}</div>
+      </div>
+      <a class="btn-outline" [routerLink]="['/times', time.id]">Detalhes</a>
+    </div>
+  </div>
+</div>

--- a/src/app/features/times/list-times/list-times.component.scss
+++ b/src/app/features/times/list-times/list-times.component.scss
@@ -1,0 +1,139 @@
+.times-page {
+  min-height: 100vh;
+  background: #f5f5f5;
+  padding: 2rem;
+  color: #333;
+}
+
+.header {
+  max-width: 980px;
+  margin: 0 auto 1.5rem;
+
+  h1 {
+    margin: 0;
+    font-size: 2rem;
+    font-weight: 700;
+    color: #333;
+  }
+}
+
+.state {
+  max-width: 980px;
+  margin: 0 auto;
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  background: #fff;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
+
+  &.loading {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    color: #666;
+  }
+
+  &.empty {
+    color: #666;
+  }
+
+  &.error {
+    background: #f8d7da;
+    color: #dc3545;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  p {
+    margin: 0;
+  }
+}
+
+.spinner {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 2px solid rgba(0, 0, 0, 0.12);
+  border-top-color: rgba(0, 0, 0, 0.5);
+  animation: spin 800ms linear infinite;
+}
+
+.grid {
+  max-width: 980px;
+  margin: 1.5rem auto 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
+  padding: 1rem 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.card-main {
+  display: grid;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.title {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  min-width: 0;
+
+  .name {
+    font-weight: 700;
+    color: #333;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .sigla {
+    font-weight: 600;
+    color: #666;
+  }
+}
+
+.meta {
+  color: #666;
+  font-size: 0.9rem;
+}
+
+.btn-primary {
+  background: #007bff;
+  color: #fff;
+  border: 0;
+  border-radius: 8px;
+  padding: 0.55rem 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn-outline {
+  border: 1px solid #007bff;
+  color: #007bff;
+  border-radius: 8px;
+  padding: 0.55rem 0.9rem;
+  font-weight: 600;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/app/features/times/list-times/list-times.component.ts
+++ b/src/app/features/times/list-times/list-times.component.ts
@@ -1,0 +1,44 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { TimesService } from '../../../core/services/times.service';
+import { Time } from '../../../core/models/time.model';
+
+@Component({
+  selector: 'app-list-times',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './list-times.component.html',
+  styleUrls: ['./list-times.component.scss']
+})
+export class ListTimesComponent implements OnInit {
+  status: 'loading' | 'error' | 'empty' | 'ready' = 'loading';
+  errorMessage = '';
+  times: Time[] = [];
+
+  constructor(private timesService: TimesService) {}
+
+  ngOnInit(): void {
+    this.loadTimes();
+  }
+
+  loadTimes(): void {
+    this.status = 'loading';
+    this.errorMessage = '';
+    this.timesService.getTimes().subscribe({
+      next: (data) => {
+        this.times = data ?? [];
+        this.status = this.times.length > 0 ? 'ready' : 'empty';
+      },
+      error: (err) => {
+        this.status = 'error';
+        this.errorMessage = 'Falha ao carregar a lista de times.';
+        console.error('Erro ao buscar times', err);
+      }
+    });
+  }
+
+  trackByTimeId(index: number, time: Time): number {
+    return time.id ?? index;
+  }
+}

--- a/src/app/features/times/time-detail-stub/time-detail-stub.component.html
+++ b/src/app/features/times/time-detail-stub/time-detail-stub.component.html
@@ -1,0 +1,10 @@
+<div class="page">
+  <div class="header">
+    <a class="btn-outline" routerLink="/times">Voltar</a>
+    <h1>Time #{{ timeId }}</h1>
+  </div>
+
+  <div class="card">
+    <p>Detalhe do time será implementado na próxima issue.</p>
+  </div>
+</div>

--- a/src/app/features/times/time-detail-stub/time-detail-stub.component.scss
+++ b/src/app/features/times/time-detail-stub/time-detail-stub.component.scss
@@ -1,0 +1,47 @@
+.page {
+  min-height: 100vh;
+  background: #f5f5f5;
+  padding: 2rem;
+  color: #333;
+}
+
+.header {
+  max-width: 980px;
+  margin: 0 auto 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+
+  h1 {
+    margin: 0;
+    font-size: 2rem;
+    font-weight: 700;
+  }
+}
+
+.card {
+  max-width: 980px;
+  margin: 0 auto;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
+  padding: 1rem 1.25rem;
+  color: #666;
+
+  p {
+    margin: 0;
+  }
+}
+
+.btn-outline {
+  border: 1px solid #007bff;
+  color: #007bff;
+  border-radius: 8px;
+  padding: 0.55rem 0.9rem;
+  font-weight: 600;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/app/features/times/time-detail-stub/time-detail-stub.component.ts
+++ b/src/app/features/times/time-detail-stub/time-detail-stub.component.ts
@@ -1,0 +1,18 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { ActivatedRoute, RouterModule } from '@angular/router';
+
+@Component({
+  selector: 'app-time-detail-stub',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './time-detail-stub.component.html',
+  styleUrls: ['./time-detail-stub.component.scss']
+})
+export class TimeDetailStubComponent {
+  timeId: number;
+
+  constructor(route: ActivatedRoute) {
+    this.timeId = Number(route.snapshot.paramMap.get('id'));
+  }
+}


### PR DESCRIPTION
## O que mudou
- Criada página /times com header Times, listagem em cards e estados de loading/erro/vazio.
- Adicionado TimesService tipado consumindo GET {apiUrl}/times.
- Botão Detalhes navega para /times/:id (rota adicionada).

## Arquivos
- src/app/core/models/time.model.ts
- src/app/core/services/times.service.ts
- src/app/features/times/list-times/*
- src/app/features/times/time-detail-stub/*
- src/app/app.routes.ts

## Observação
- A tela de /times/:id está como stub apenas para não quebrar a navegação. O detalhe completo será implementado na issue #10.

Closes #9