### PR TITLE
feat: detalhe do time

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -29,7 +29,7 @@ export const routes: Routes = [
   {
     path: 'times/:id',
     canMatch: [authGuard],
-    loadComponent: () => import('./features/times/time-detail-stub/time-detail-stub.component').then(m => m.TimeDetailStubComponent)
+    loadComponent: () => import('./features/times/time-detail-stub/time-detail-stub.component').then(m => m.TimeDetailComponent)
   },
   {
     path: 'times',

--- a/src/app/core/models/time.model.ts
+++ b/src/app/core/models/time.model.ts
@@ -3,3 +3,21 @@ export type Time = {
   nome?: string;
   sigla?: string;
 };
+
+export type TimeJogador = {
+  id: number;
+  nome: string;
+  carteiraStellar?: string | null;
+};
+
+export type TimeJogoResumo = {
+  idTime?: number;
+  idJogo: number;
+  pontuacao: number;
+  vencedor: boolean;
+};
+
+export type TimeDetail = Time & {
+  jogadors?: TimeJogador[];
+  timeJogos?: TimeJogoResumo[];
+};

--- a/src/app/core/services/times.service.ts
+++ b/src/app/core/services/times.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
-import { Time } from '../models/time.model';
+import { Time, TimeDetail } from '../models/time.model';
 
 @Injectable({
   providedIn: 'root'
@@ -14,5 +14,9 @@ export class TimesService {
 
   getTimes(): Observable<Time[]> {
     return this.http.get<Time[]>(`${this.apiUrl}/times`);
+  }
+
+  getTimeById(id: number): Observable<TimeDetail> {
+    return this.http.get<TimeDetail>(`${this.apiUrl}/times/${id}`);
   }
 }

--- a/src/app/features/times/time-detail-stub/time-detail-stub.component.html
+++ b/src/app/features/times/time-detail-stub/time-detail-stub.component.html
@@ -1,10 +1,85 @@
 <div class="page">
   <div class="header">
     <a class="btn-outline" routerLink="/times">Voltar</a>
-    <h1>Time #{{ timeId }}</h1>
+    <h1>Time #{{ timeId ?? '—' }}</h1>
   </div>
 
-  <div class="card">
-    <p>Detalhe do time será implementado na próxima issue.</p>
+  <div *ngIf="status === 'loading'" class="state loading" role="status" aria-live="polite">
+    <span class="spinner" aria-hidden="true"></span>
+    <p>Carregando time...</p>
+  </div>
+
+  <div *ngIf="status === 'error'" class="state error" role="alert">
+    <p>{{ errorMessage }}</p>
+    <button type="button" class="btn-primary" (click)="loadTime()">Tentar novamente</button>
+  </div>
+
+  <div *ngIf="status === 'not_found'" class="state error" role="alert">
+    <p>Time não encontrado.</p>
+    <a class="btn-primary" routerLink="/times">Voltar para a lista</a>
+  </div>
+
+  <div *ngIf="status === 'ready' && time" class="content">
+    <div class="card">
+      <div class="card-title">Dados do time</div>
+      <div class="kv">
+        <div class="row">
+          <div class="label">ID</div>
+          <div class="value">{{ time.id }}</div>
+        </div>
+        <div class="row">
+          <div class="label">Nome</div>
+          <div class="value">{{ time.nome || '—' }}</div>
+        </div>
+        <div class="row">
+          <div class="label">Sigla</div>
+          <div class="value">{{ time.sigla || '—' }}</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card" *ngIf="time.jogadors?.length">
+      <div class="card-title">Jogadores</div>
+      <div class="table-wrap">
+        <table class="table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Nome</th>
+              <th>Carteira Stellar</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let jogador of time.jogadors">
+              <td>{{ jogador.id }}</td>
+              <td>{{ jogador.nome }}</td>
+              <td>{{ jogador.carteiraStellar || '—' }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="card" *ngIf="time.timeJogos?.length">
+      <div class="card-title">Jogos</div>
+      <div class="table-wrap">
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Jogo</th>
+              <th>Pontuação</th>
+              <th>Vencedor</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let jogo of time.timeJogos">
+              <td>#{{ jogo.idJogo }}</td>
+              <td>{{ jogo.pontuacao }}</td>
+              <td>{{ jogo.vencedor ? 'Sim' : 'Não' }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </div>

--- a/src/app/features/times/time-detail-stub/time-detail-stub.component.scss
+++ b/src/app/features/times/time-detail-stub/time-detail-stub.component.scss
@@ -20,17 +20,127 @@
   }
 }
 
-.card {
+.state {
   max-width: 980px;
   margin: 0 auto;
-  background: #fff;
   border-radius: 8px;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
   padding: 1rem 1.25rem;
-  color: #666;
+  background: #fff;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
+
+  &.loading {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    color: #666;
+  }
+
+  &.error {
+    background: #f8d7da;
+    color: #dc3545;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
 
   p {
     margin: 0;
+  }
+}
+
+.spinner {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 2px solid rgba(0, 0, 0, 0.12);
+  border-top-color: rgba(0, 0, 0, 0.5);
+  animation: spin 800ms linear infinite;
+}
+
+.content {
+  max-width: 980px;
+  margin: 0 auto;
+  display: grid;
+  gap: 1rem;
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 8px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
+  padding: 1rem 1.25rem;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+
+  &:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 26px rgba(0, 0, 0, 0.08);
+  }
+}
+
+.card-title {
+  font-weight: 700;
+  color: #333;
+  margin-bottom: 0.75rem;
+}
+
+.kv {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 0.75rem;
+  align-items: baseline;
+}
+
+.label {
+  color: #666;
+  font-weight: 600;
+}
+
+.value {
+  color: #333;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.table-wrap {
+  overflow: auto;
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+
+  th,
+  td {
+    text-align: left;
+    padding: 0.75rem 0.85rem;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+    white-space: nowrap;
+  }
+
+  th {
+    background: rgba(0, 0, 0, 0.03);
+    color: #333;
+    font-weight: 700;
+  }
+
+  td {
+    color: #666;
+  }
+
+  tbody tr:hover td {
+    background: rgba(0, 123, 255, 0.06);
+    color: #333;
   }
 }
 
@@ -44,4 +154,36 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  transition: background 160ms ease, transform 160ms ease;
+
+  &:hover {
+    background: rgba(0, 123, 255, 0.08);
+    transform: translateY(-1px);
+  }
+}
+
+.btn-primary {
+  background: #007bff;
+  color: #fff;
+  border: 0;
+  border-radius: 8px;
+  padding: 0.55rem 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: filter 160ms ease, transform 160ms ease;
+
+  &:hover {
+    filter: brightness(1.03);
+    transform: translateY(-1px);
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }

--- a/src/app/features/times/time-detail-stub/time-detail-stub.component.ts
+++ b/src/app/features/times/time-detail-stub/time-detail-stub.component.ts
@@ -1,18 +1,67 @@
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, RouterModule } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { TimesService } from '../../../core/services/times.service';
+import { TimeDetail } from '../../../core/models/time.model';
 
 @Component({
-  selector: 'app-time-detail-stub',
+  selector: 'app-time-detail',
   standalone: true,
   imports: [CommonModule, RouterModule],
   templateUrl: './time-detail-stub.component.html',
   styleUrls: ['./time-detail-stub.component.scss']
 })
-export class TimeDetailStubComponent {
-  timeId: number;
+export class TimeDetailComponent implements OnInit {
+  status: 'loading' | 'error' | 'not_found' | 'ready' = 'loading';
+  timeId: number | null = null;
+  errorMessage = '';
+  time: TimeDetail | null = null;
 
-  constructor(route: ActivatedRoute) {
-    this.timeId = Number(route.snapshot.paramMap.get('id'));
+  constructor(
+    private route: ActivatedRoute,
+    private timesService: TimesService
+  ) {}
+
+  ngOnInit(): void {
+    const idParam = this.route.snapshot.paramMap.get('id');
+    const id = Number(idParam);
+
+    if (!idParam || Number.isNaN(id) || !Number.isInteger(id) || id <= 0) {
+      this.status = 'error';
+      this.errorMessage = 'ID de time inválido.';
+      return;
+    }
+
+    this.timeId = id;
+    this.loadTime();
+  }
+
+  loadTime(): void {
+    if (this.timeId === null) {
+      this.status = 'error';
+      this.errorMessage = 'ID de time inválido.';
+      return;
+    }
+
+    this.status = 'loading';
+    this.errorMessage = '';
+    this.time = null;
+
+    this.timesService.getTimeById(this.timeId).subscribe({
+      next: (data) => {
+        this.time = data;
+        this.status = 'ready';
+      },
+      error: (err: unknown) => {
+        if (err instanceof HttpErrorResponse && err.status === 404) {
+          this.status = 'not_found';
+          return;
+        }
+
+        this.status = 'error';
+        this.errorMessage = 'Falha ao carregar o time.';
+      }
+    });
   }
 }


### PR DESCRIPTION
## O que mudou
- Implementada a tela de detalhe do time em /times/:id com header, card de dados e tabelas para listas do payload (jogadores e jogos).
- Adicionados estados de loading, erro e 404 ('Time não encontrado') com retry e navegação de volta.
- Tipagem do payload de detalhe e integração com a API GET /times/{id}.

## Por que mudou
- src/app/app.routes.ts: expõe a rota /times/:id e carrega o componente de detalhe.
- src/app/core/models/time.model.ts: define TimeDetail/TimeJogador/TimeJogoResumo para tipar o retorno do backend e evitar any.
- src/app/core/services/times.service.ts: adiciona getTimeById(id) para centralizar a chamada HTTP ao endpoint do detalhe.
- src/app/features/times/time-detail-stub/*: substitui o stub por uma UI completa, com estados e layout consistente com o restante do app.

## Contexto
Closes #10

## Verificação
- npm test -- --watch=false --browsers=ChromeHeadless
- npm run build