### PR TITLE
feat: estatísticas - top scorers

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -42,6 +42,14 @@ export const routes: Routes = [
     loadComponent: () => import('./features/times/list-times/list-times.component').then(m => m.ListTimesComponent)
   },
   {
+    path: 'estatisticas/top',
+    canMatch: [authGuard],
+    loadComponent: () =>
+      import('./features/estatisticas/top-scorers/top-scorers.component').then(
+        m => m.TopScorersComponent
+      )
+  },
+  {
     path: '',
     redirectTo: 'jogos',
     pathMatch: 'full'

--- a/src/app/core/services/estatisticas.service.ts
+++ b/src/app/core/services/estatisticas.service.ts
@@ -1,0 +1,40 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { map, Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+export type TopScorer = {
+  jogadorId: number;
+  nome: string;
+  pontos: number;
+};
+
+type TopScorerApiDto = {
+  jogadorId: number;
+  nome: string;
+  pontos: number | string;
+};
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EstatisticasService {
+  private readonly apiUrl = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  getTopScorers(limit: number): Observable<TopScorer[]> {
+    return this.http
+      .get<TopScorerApiDto[]>(`${this.apiUrl}/estatisticas/top-scorers/${limit}`)
+      .pipe(
+        map((rows) =>
+          (rows ?? []).map((row) => ({
+            jogadorId: Number(row.jogadorId),
+            nome: String(row.nome ?? ''),
+            pontos: Number(row.pontos ?? 0)
+          }))
+        ),
+        map((items) => [...items].sort((a, b) => b.pontos - a.pontos).slice(0, limit))
+      );
+  }
+}

--- a/src/app/features/estatisticas/top-scorers/top-scorers.component.html
+++ b/src/app/features/estatisticas/top-scorers/top-scorers.component.html
@@ -1,0 +1,102 @@
+<div class="stats-container">
+  <div class="header-section">
+    <div class="title-wrapper">
+      <h2>Top scorers</h2>
+      <p>Ranking de jogadores por pontos marcados</p>
+    </div>
+
+    <a class="btn-ghost" routerLink="/jogos">Voltar</a>
+  </div>
+
+  <div class="glass-card controls-card">
+    <form class="controls-form" [formGroup]="form" (ngSubmit)="onCarregar()">
+      <div class="field">
+        <label class="label-text" for="limit">Limite</label>
+        <input
+          id="limit"
+          type="number"
+          inputmode="numeric"
+          class="input-field"
+          formControlName="limit"
+          min="1"
+          max="100"
+          step="1"
+          placeholder="Ex: 10"
+          [attr.aria-invalid]="limitCtrl.touched && limitCtrl.invalid ? true : null"
+        />
+        <div class="error-text" *ngIf="limitCtrl.touched && limitCtrl.invalid" role="alert">
+          <span *ngIf="limitCtrl.errors?.['required']">Informe o limite.</span>
+          <span *ngIf="limitCtrl.errors?.['min'] || limitCtrl.errors?.['max']">Use um valor entre 1 e 100.</span>
+          <span *ngIf="limitCtrl.errors?.['integer']">Use um número inteiro.</span>
+        </div>
+      </div>
+
+      <button type="submit" class="btn-primary" [disabled]="form.invalid || state.status === 'loading'">
+        <span *ngIf="state.status !== 'loading'">Carregar</span>
+        <span *ngIf="state.status === 'loading'" class="loading-inline">
+          <span class="mini-loader" aria-hidden="true"></span>
+          Carregando...
+        </span>
+      </button>
+    </form>
+  </div>
+
+  <div *ngIf="state.status === 'idle'" class="glass-card hint-card">
+    <div class="hint-icon" aria-hidden="true">📈</div>
+    <div class="hint-content">
+      <div class="hint-title">Pronto para buscar</div>
+      <div class="hint-subtitle">Defina o limite e clique em “Carregar”.</div>
+    </div>
+  </div>
+
+  <div *ngIf="state.status === 'loading'" class="loading-state">
+    <span class="loader"></span>
+    <p>Carregando ranking...</p>
+  </div>
+
+  <div *ngIf="errorMessage as msg" class="glass-card alert error" role="alert">
+    <div class="icon" aria-hidden="true">
+      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+    </div>
+    <div class="message">{{ msg }}</div>
+    <button type="button" class="btn-primary" (click)="onCarregar()" [disabled]="form.invalid || state.status === 'loading'">
+      Tentar novamente
+    </button>
+  </div>
+
+  <div *ngIf="state.status === 'empty'" class="glass-card empty-state">
+    <div class="empty-icon" aria-hidden="true">—</div>
+    <h3>Nenhum resultado</h3>
+    <p>Não há pontuações registradas para exibir no momento.</p>
+  </div>
+
+  <div *ngIf="state.status === 'ready'" class="glass-card table-card">
+    <div class="table-header">
+      <div class="table-title">Ranking</div>
+      <div class="table-subtitle">{{ readyItems.length }} jogadores</div>
+    </div>
+
+    <div class="table">
+      <div class="thead">
+        <div>#</div>
+        <div>Jogador</div>
+        <div class="right">Pontos</div>
+      </div>
+      <div
+        class="row"
+        *ngFor="let item of readyItems; let i = index; trackBy: trackByJogadorId"
+      >
+        <div class="rank">
+          <span class="pill">{{ i + 1 }}</span>
+        </div>
+        <div class="player">
+          <div class="name">{{ item.nome }}</div>
+          <div class="meta">ID {{ item.jogadorId }}</div>
+        </div>
+        <div class="points right">
+          <span class="points-value">{{ item.pontos }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/features/estatisticas/top-scorers/top-scorers.component.scss
+++ b/src/app/features/estatisticas/top-scorers/top-scorers.component.scss
@@ -1,0 +1,313 @@
+.stats-container {
+  padding: 3rem 2rem;
+  max-width: 1100px;
+  margin: 0 auto;
+  animation: fadeIn 0.6s ease-out;
+}
+
+.header-section {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 2rem;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+
+  .title-wrapper {
+    h2 {
+      font-size: 2.25rem;
+      font-weight: 800;
+      margin-bottom: 0.5rem;
+      background: linear-gradient(to right, #fff, #94a3b8);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+
+    p {
+      color: var(--text-secondary);
+      font-size: 1.05rem;
+    }
+  }
+}
+
+.btn-ghost {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: white;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  font-weight: 700;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s, border-color 0.2s, background 0.2s;
+
+  &:hover {
+    transform: translateY(-2px);
+    background: rgba(255, 255, 255, 0.08);
+    border-color: rgba(99, 102, 241, 0.4);
+  }
+}
+
+.controls-card {
+  padding: 1.25rem;
+  margin-bottom: 1.25rem;
+}
+
+.controls-form {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 1rem;
+  align-items: end;
+}
+
+.field {
+  min-width: 240px;
+}
+
+.loading-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.mini-loader {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  border-top-color: rgba(255, 255, 255, 0.95);
+  animation: spin 800ms linear infinite;
+}
+
+.loading-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 4rem 2rem;
+  color: var(--text-secondary);
+
+  .loader {
+    width: 44px;
+    height: 44px;
+    border: 3px solid rgba(99, 102, 241, 0.18);
+    border-radius: 50%;
+    border-top-color: var(--primary);
+    animation: spin 1s linear infinite;
+  }
+}
+
+.hint-card {
+  padding: 1.25rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 1.25rem;
+  border: 1px solid rgba(99, 102, 241, 0.15);
+  background: rgba(99, 102, 241, 0.06);
+
+  .hint-icon {
+    width: 44px;
+    height: 44px;
+    border-radius: 1rem;
+    display: grid;
+    place-items: center;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    filter: drop-shadow(0 12px 22px rgba(99, 102, 241, 0.25));
+    font-size: 1.25rem;
+  }
+
+  .hint-title {
+    font-weight: 800;
+    color: white;
+  }
+
+  .hint-subtitle {
+    color: var(--text-secondary);
+    margin-top: 0.25rem;
+  }
+}
+
+.alert {
+  margin-top: 1.25rem;
+  padding: 1rem 1.25rem;
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+
+  .message {
+    flex: 1;
+    font-weight: 700;
+  }
+
+  &.error {
+    border: 1px solid rgba(239, 68, 68, 0.25);
+    background: rgba(239, 68, 68, 0.08);
+    color: #fca5a5;
+  }
+}
+
+.empty-state {
+  margin-top: 1.25rem;
+  padding: 3rem 2rem;
+  text-align: center;
+  display: grid;
+  gap: 0.75rem;
+
+  .empty-icon {
+    font-size: 3rem;
+    opacity: 0.85;
+  }
+
+  h3 {
+    color: white;
+    font-size: 1.4rem;
+  }
+
+  p {
+    color: var(--text-secondary);
+    max-width: 420px;
+    margin: 0 auto;
+  }
+}
+
+.table-card {
+  margin-top: 1.25rem;
+  padding: 1.25rem;
+}
+
+.table-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+
+  .table-title {
+    font-weight: 900;
+    font-size: 1.1rem;
+    color: white;
+    letter-spacing: 0.02em;
+  }
+
+  .table-subtitle {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+  }
+}
+
+.table {
+  display: grid;
+  gap: 0.5rem;
+
+  .thead {
+    display: grid;
+    grid-template-columns: 72px 1fr 120px;
+    gap: 1rem;
+    padding: 0.75rem 0.75rem;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .row {
+    display: grid;
+    grid-template-columns: 72px 1fr 120px;
+    gap: 1rem;
+    padding: 0.85rem 0.75rem;
+    border-radius: 0.9rem;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    transition: transform 0.2s, border-color 0.2s, background 0.2s;
+
+    &:hover {
+      transform: translateY(-2px);
+      border-color: rgba(99, 102, 241, 0.25);
+      background: rgba(255, 255, 255, 0.05);
+    }
+  }
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 34px;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.12);
+  color: #c7d2fe;
+  border: 1px solid rgba(99, 102, 241, 0.2);
+  font-weight: 900;
+  font-size: 0.85rem;
+}
+
+.player {
+  min-width: 0;
+
+  .name {
+    font-weight: 800;
+    color: white;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .meta {
+    margin-top: 0.15rem;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+  }
+}
+
+.points-value {
+  font-family: 'Mono', monospace;
+  font-weight: 900;
+  font-size: 1.05rem;
+  color: #e2e8f0;
+}
+
+.right {
+  text-align: right;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 720px) {
+  .stats-container {
+    padding: 2rem 1rem;
+  }
+
+  .controls-form {
+    grid-template-columns: 1fr;
+  }
+
+  .table {
+    .thead,
+    .row {
+      grid-template-columns: 64px 1fr 96px;
+    }
+  }
+}

--- a/src/app/features/estatisticas/top-scorers/top-scorers.component.ts
+++ b/src/app/features/estatisticas/top-scorers/top-scorers.component.ts
@@ -1,0 +1,105 @@
+import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component } from '@angular/core';
+import {
+  AbstractControl,
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  ValidationErrors,
+  ValidatorFn,
+  Validators
+} from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { EstatisticasService, TopScorer } from '../../../core/services/estatisticas.service';
+
+type TopScorersState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'ready'; items: TopScorer[] }
+  | { status: 'empty' }
+  | { status: 'error'; message: string };
+
+type TopScorersForm = FormGroup<{
+  limit: FormControl<number | null>;
+}>;
+
+const integerValidator: ValidatorFn = (
+  control: AbstractControl<number | null>
+): ValidationErrors | null => {
+  const value = control.value;
+  if (value === null || value === undefined) return null;
+  if (typeof value !== 'number' || Number.isNaN(value)) return { integer: true };
+  return Number.isInteger(value) ? null : { integer: true };
+};
+
+@Component({
+  selector: 'app-top-scorers',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterModule],
+  templateUrl: './top-scorers.component.html',
+  styleUrls: ['./top-scorers.component.scss']
+})
+export class TopScorersComponent {
+  state: TopScorersState = { status: 'idle' };
+
+  form: TopScorersForm = new FormGroup({
+    limit: new FormControl<number | null>(10, {
+      validators: [Validators.required, integerValidator, Validators.min(1), Validators.max(100)]
+    })
+  });
+
+  get limitCtrl(): FormControl<number | null> {
+    return this.form.controls.limit;
+  }
+
+  constructor(private estatisticasService: EstatisticasService) {}
+
+  onCarregar(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      this.state = { status: 'idle' };
+      return;
+    }
+
+    const limit = this.form.getRawValue().limit;
+    if (limit === null || !Number.isInteger(limit) || limit < 1 || limit > 100) {
+      this.form.markAllAsTouched();
+      this.state = { status: 'idle' };
+      return;
+    }
+
+    this.state = { status: 'loading' };
+    this.estatisticasService.getTopScorers(limit).subscribe({
+      next: (items) => {
+        const normalized = items ?? [];
+        this.state = normalized.length > 0 ? { status: 'ready', items: normalized } : { status: 'empty' };
+      },
+      error: (err: unknown) => {
+        if (err instanceof HttpErrorResponse) {
+          if (err.status === 400) {
+            this.state = { status: 'error', message: 'Limite inválido. Use um inteiro entre 1 e 100.' };
+            return;
+          }
+          if (err.status === 401) {
+            this.state = { status: 'error', message: 'Sessão expirada. Faça login novamente.' };
+            return;
+          }
+        }
+        this.state = { status: 'error', message: 'Falha ao carregar top scorers.' };
+      }
+    });
+  }
+
+  trackByJogadorId(index: number, item: TopScorer): number {
+    return item.jogadorId ?? index;
+  }
+
+  get readyItems(): TopScorer[] {
+    return this.state.status === 'ready' ? this.state.items : [];
+  }
+
+  get errorMessage(): string | null {
+    return this.state.status === 'error' ? this.state.message : null;
+  }
+}


### PR DESCRIPTION
## O que mudou\n- Adiciona rota protegida /estatisticas/top carregada via lazy load.\n- Cria TopScorersComponent com formulário de limite (1..100), validação e estados (idle/loading/erro/vazio).\n- Cria EstatisticasService tipado para consumir GET /estatisticas/top-scorers/{limit} e normalizar o retorno.\n\n## Por que mudou\n- src/app/app.routes.ts: expõe a página de estatísticas via rota dedicada, seguindo o padrão de rotas standalone e proteção por uthGuard.\n- src/app/core/services/estatisticas.service.ts: centraliza integração com a API e tipa/normaliza pontos (o backend pode retornar string via agregação).\n- src/app/features/estatisticas/top-scorers/*: implementa a UI e o fluxo de carregamento com feedback premium (dark + glass) e responsividade.\n\n## Contexto\nRelacionado à #12