### PR TITLE
feat: gate admin para criacao de jogo

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,6 +1,6 @@
 import { Routes } from '@angular/router';
 import { guestGuard } from './core/guards/guest.guard';
-import { authGuard } from './core/guards/auth.guards';
+import { adminGuard, authGuard } from './core/guards/auth.guards';
 
 export const routes: Routes = [
   {
@@ -32,7 +32,7 @@ export const routes: Routes = [
   },
   {
     path: 'jogos/criar',
-    canMatch: [authGuard],
+    canMatch: [authGuard, adminGuard],
     loadComponent: () => import('./features/jogos/criacao-jogo/criacao-jogo.component').then(m => m.CriacaoJogoComponent)
   },
   {

--- a/src/app/core/guards/auth.guards.ts
+++ b/src/app/core/guards/auth.guards.ts
@@ -1,6 +1,8 @@
 import { inject } from '@angular/core';
 import { CanMatchFn, Router } from '@angular/router';
+import { catchError, map, of } from 'rxjs';
 import { AuthService } from '../services/auth.service';
+import { RolesService } from '../services/roles.service';
 
 export const authGuard: CanMatchFn = () => {
   const authService = inject(AuthService);
@@ -11,4 +13,26 @@ export const authGuard: CanMatchFn = () => {
   }
 
   return router.createUrlTree(['/login']);
+};
+
+export const adminGuard: CanMatchFn = () => {
+  const authService = inject(AuthService);
+  const rolesService = inject(RolesService);
+  const router = inject(Router);
+
+  const tokenHasAdmin = authService.hasRoleFromToken('ADMIN');
+  if (tokenHasAdmin === true) {
+    return true;
+  }
+  if (tokenHasAdmin === false) {
+    return router.createUrlTree(['/jogos']);
+  }
+
+  return rolesService.getRoles().pipe(
+    map((roles) => {
+      const isAdmin = roles.some((role) => role.nome.trim().toUpperCase() === 'ADMIN');
+      return isAdmin ? true : router.createUrlTree(['/jogos']);
+    }),
+    catchError(() => of(router.createUrlTree(['/jogos'])))
+  );
 };

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -9,6 +9,72 @@ export interface LoginResponse {
   access_token: string;
 }
 
+type JwtTokenPayload = {
+  exp?: number;
+  roles?: unknown;
+  role?: unknown;
+} & Record<string, unknown>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function normalizeRoleName(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const normalized = value.trim().toUpperCase();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function extractRoleNamesFromToken(payload: JwtTokenPayload): string[] | null {
+  const rolesValue = payload.roles ?? payload.role;
+
+  const rolesFromArray = (arr: unknown[]): string[] => {
+    const roles: string[] = [];
+    for (const item of arr) {
+      const fromString = normalizeRoleName(item);
+      if (fromString) {
+        roles.push(fromString);
+        continue;
+      }
+
+      if (isRecord(item)) {
+        const fromObj =
+          normalizeRoleName(item['nome']) ??
+          normalizeRoleName(item['name']) ??
+          normalizeRoleName(item['role']);
+        if (fromObj) {
+          roles.push(fromObj);
+        }
+      }
+    }
+    return roles;
+  };
+
+  if (Array.isArray(rolesValue)) {
+    return rolesFromArray(rolesValue);
+  }
+
+  if (typeof rolesValue === 'string') {
+    const parts = rolesValue
+      .split(',')
+      .map((p) => normalizeRoleName(p))
+      .filter((p): p is string => Boolean(p));
+    return parts.length > 0 ? parts : null;
+  }
+
+  if (isRecord(rolesValue)) {
+    const fromObj =
+      normalizeRoleName(rolesValue['nome']) ??
+      normalizeRoleName(rolesValue['name']) ??
+      normalizeRoleName(rolesValue['role']);
+    return fromObj ? [fromObj] : null;
+  }
+
+  return rolesValue === undefined ? null : [];
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -18,9 +84,6 @@ export class AuthService {
   constructor(private http: HttpClient) {}
 
   login(credentials: { login: string; senha?: string }): Observable<LoginResponse> {
-    // We assume the backend route will be /usuario/login or /auth/login based on current implementation
-    // For now we use /usuario since that controller exists, or we can use /login.
-    // Given backend structure, it seems the method validaLogin is inside usuario.service
     return this.http.post<LoginResponse>(`${this.apiUrl}/auth/login`, credentials);
   }
 
@@ -32,19 +95,46 @@ export class AuthService {
     return localStorage.getItem('auth_token');
   }
 
-  isAuthenticated(): boolean {
+  getDecodedToken(): JwtTokenPayload | null {
     const token = this.getToken();
     if (!token) {
-      return false;
+      return null;
     }
 
     try {
-      const decoded: any = jwtDecode(token);
-      const currentTime = Math.floor(Date.now() / 1000);
-      return decoded.exp > currentTime;
-    } catch (error) {
+      return jwtDecode<JwtTokenPayload>(token);
+    } catch {
+      return null;
+    }
+  }
+
+  isAuthenticated(): boolean {
+    const decoded = this.getDecodedToken();
+    if (!decoded || typeof decoded.exp !== 'number') {
       return false;
     }
+
+    const currentTime = Math.floor(Date.now() / 1000);
+    return decoded.exp > currentTime;
+  }
+
+  hasRoleFromToken(roleName: string): boolean | null {
+    const decoded = this.getDecodedToken();
+    if (!decoded) {
+      return null;
+    }
+
+    const roles = extractRoleNamesFromToken(decoded);
+    if (roles === null) {
+      return null;
+    }
+
+    const normalized = normalizeRoleName(roleName);
+    if (!normalized) {
+      return false;
+    }
+
+    return roles.includes(normalized);
   }
 
   logout(): void {

--- a/src/app/features/jogos/list-jogos/list-jogos.component.html
+++ b/src/app/features/jogos/list-jogos/list-jogos.component.html
@@ -4,10 +4,12 @@
       <h2>Lista de Jogos</h2>
       <p>Acompanhe o histórico de partidas e os resultados</p>
     </div>
-    <button class="btn-primary" routerLink="/jogos/criar">
+    <button *ngIf="canCreateJogo" class="btn-primary" routerLink="/jogos/criar">
       <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
       Novo Jogo
     </button>
+    <span *ngIf="adminGateStatus === 'loading'" class="permission-hint">Verificando permissão...</span>
+    <span *ngIf="adminGateStatus === 'error'" class="permission-hint permission-error">{{ adminGateErrorMessage }}</span>
   </div>
 
   <div *ngIf="isLoading" class="loading-state">
@@ -24,8 +26,9 @@
   <div *ngIf="!isLoading && jogos.length === 0" class="empty-state glass-card">
     <div class="empty-icon">🎮</div>
     <h3>Nenhum jogo encontrado</h3>
-    <p>Comece criando o primeiro jogo da temporada!</p>
-    <button class="btn-primary" routerLink="/jogos/criar">Criar Jogo</button>
+    <p *ngIf="canCreateJogo">Comece criando o primeiro jogo da temporada!</p>
+    <p *ngIf="!canCreateJogo">Você não tem permissão para criar jogos.</p>
+    <button *ngIf="canCreateJogo" class="btn-primary" routerLink="/jogos/criar">Criar Jogo</button>
   </div>
 
   <div *ngIf="!isLoading && jogos.length > 0" class="cards-grid">

--- a/src/app/features/jogos/list-jogos/list-jogos.component.scss
+++ b/src/app/features/jogos/list-jogos/list-jogos.component.scss
@@ -33,6 +33,22 @@
     align-items: center;
     gap: 0.5rem;
   }
+
+  .permission-hint {
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.75rem;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    white-space: nowrap;
+  }
+
+  .permission-error {
+    color: #fca5a5;
+    border-color: rgba(239, 68, 68, 0.25);
+    background: rgba(239, 68, 68, 0.08);
+  }
 }
 
 .loading-state {

--- a/src/app/features/jogos/list-jogos/list-jogos.component.ts
+++ b/src/app/features/jogos/list-jogos/list-jogos.component.ts
@@ -1,8 +1,11 @@
+import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
+import { AuthService } from '../../../core/services/auth.service';
 import { JogoService } from '../../../core/services/jogo.service';
 import { JogoComDetalhes } from '../../../core/models/jogo.model';
+import { RolesService } from '../../../core/services/roles.service';
 
 type ResultadosState = {
   status: 'idle' | 'loading' | 'loaded' | 'error';
@@ -22,10 +25,43 @@ export class ListJogosComponent implements OnInit {
   isLoading = true;
   errorMessage = '';
 
-  constructor(private jogoService: JogoService) {}
+  adminGateStatus: 'loading' | 'ready' | 'error' = 'loading';
+  adminGateErrorMessage = '';
+  canCreateJogo = false;
+
+  constructor(
+    private authService: AuthService,
+    private jogoService: JogoService,
+    private rolesService: RolesService
+  ) {}
 
   ngOnInit(): void {
+    this.loadAdminGate();
     this.loadJogos();
+  }
+
+  loadAdminGate(): void {
+    this.adminGateStatus = 'loading';
+    this.adminGateErrorMessage = '';
+
+    const tokenHasAdmin = this.authService.hasRoleFromToken('ADMIN');
+    if (tokenHasAdmin !== null) {
+      this.canCreateJogo = tokenHasAdmin;
+      this.adminGateStatus = 'ready';
+      return;
+    }
+
+    this.rolesService.getRoles().subscribe({
+      next: (roles) => {
+        this.canCreateJogo = (roles ?? []).some((role) => role.nome.trim().toUpperCase() === 'ADMIN');
+        this.adminGateStatus = 'ready';
+      },
+      error: (err: unknown) => {
+        this.canCreateJogo = false;
+        this.adminGateStatus = 'error';
+        this.adminGateErrorMessage = this.getFriendlyAdminGateErrorMessage(err);
+      }
+    });
   }
 
   loadJogos(): void {
@@ -37,7 +73,7 @@ export class ListJogosComponent implements OnInit {
         this.jogos.forEach((jogo) => this.loadResultadosForJogo(jogo));
         this.isLoading = false;
       },
-      error: (err) => {
+      error: (err: unknown) => {
         this.isLoading = false;
         this.errorMessage = 'Falha ao carregar a lista de jogos.';
         console.error('Erro ao buscar jogos', err);
@@ -54,7 +90,7 @@ export class ListJogosComponent implements OnInit {
         jogo.resultados = resultados;
         this.resultadosStateByJogoId.set(jogo.id, { status: 'loaded' });
       },
-      error: (err) => {
+      error: (err: unknown) => {
         jogo.resultados = [];
         this.resultadosStateByJogoId.set(jogo.id, {
           status: 'error',
@@ -67,5 +103,17 @@ export class ListJogosComponent implements OnInit {
 
   trackByJogoId(index: number, jogo: JogoComDetalhes): number {
     return jogo.id ?? index;
+  }
+
+  private getFriendlyAdminGateErrorMessage(err: unknown): string {
+    if (err instanceof HttpErrorResponse) {
+      if (err.status === 401) {
+        return 'Sua sessão expirou. Faça login novamente.';
+      }
+      if (err.status === 403) {
+        return 'Sem permissão para criar jogos.';
+      }
+    }
+    return 'Não foi possível verificar permissão de ADMIN.';
   }
 }


### PR DESCRIPTION
## O que mudou
- Botao 'Novo Jogo' aparece apenas para ADMIN em /jogos.
- Rota /jogos/criar bloqueada para nao-ADMIN via guard (canMatch).

## Por que mudou
- src/app/features/jogos/list-jogos/list-jogos.component.*: aplicar gate de UI e feedback de permissao.
- src/app/app.routes.ts + src/app/core/guards/auth.guards.ts: bloquear acesso direto por URL.
- src/app/core/services/auth.service.ts: suporte a leitura de roles do token quando disponivel.

## Contexto
Closes #15