### PR TITLE
test: adicionar testes de services HTTP (Closes #18)

### DIFF
--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -1,0 +1,72 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { AuthService, LoginResponse } from './auth.service';
+import { environment } from '../../../environments/environment';
+
+type JasmineExpectation = {
+  toBeTruthy: () => void;
+  toEqual: (expected: unknown) => void;
+  toBe: (expected: unknown) => void;
+  toBeNull: () => void;
+};
+
+declare const describe: (name: string, fn: () => void) => void;
+declare const beforeEach: (fn: () => void | Promise<void>) => void;
+declare const afterEach: (fn: () => void | Promise<void>) => void;
+declare const it: (name: string, fn: (done: DoneFn) => void) => void;
+declare const expect: (actual: unknown) => JasmineExpectation;
+declare const fail: (message?: string) => void;
+interface DoneFn {
+  (): void;
+  fail: (message?: string | Error) => void;
+}
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
+    service = TestBed.inject(AuthService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('deve fazer POST para /auth/login com body correto e retornar o token', (done) => {
+    const credentials = { login: 'user', senha: 'pass' };
+    const mockResponse: LoginResponse = { access_token: 'abc123' };
+
+    service.login(credentials).subscribe({
+      next: (resp) => {
+        expect(resp).toEqual(mockResponse);
+        done();
+      },
+      error: () => fail('não deveria falhar')
+    });
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/auth/login`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(credentials);
+    req.flush(mockResponse);
+  });
+
+  it('deve propagar erro de HTTP em login', (done) => {
+    const credentials = { login: 'user', senha: 'pass' };
+
+    service.login(credentials).subscribe({
+      next: () => fail('deveria falhar'),
+      error: () => {
+        done();
+      }
+    });
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/auth/login`);
+    expect(req.request.method).toBe('POST');
+    req.flush({ message: 'unauthorized' }, { status: 401, statusText: 'Unauthorized' });
+  });
+});

--- a/src/app/core/services/estatisticas.service.spec.ts
+++ b/src/app/core/services/estatisticas.service.spec.ts
@@ -1,0 +1,71 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { EstatisticasService, TopScorer } from './estatisticas.service';
+import { environment } from '../../../environments/environment';
+
+type JasmineExpectation = {
+  toEqual: (expected: unknown) => void;
+  toBe: (expected: unknown) => void;
+};
+
+declare const describe: (name: string, fn: () => void) => void;
+declare const beforeEach: (fn: () => void | Promise<void>) => void;
+declare const afterEach: (fn: () => void | Promise<void>) => void;
+declare const it: (name: string, fn: (done: DoneFn) => void) => void;
+declare const expect: (actual: unknown) => JasmineExpectation;
+declare const fail: (message?: string) => void;
+interface DoneFn {
+  (): void;
+  fail: (message?: string | Error) => void;
+}
+
+describe('EstatisticasService', () => {
+  let service: EstatisticasService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
+    service = TestBed.inject(EstatisticasService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('getTopScorers deve normalizar pontos numéricos e limitar resultados', (done) => {
+    const limit = 3;
+    const apiMock = [
+      { jogadorId: 1, nome: 'A', pontos: '10' },
+      { jogadorId: 2, nome: 'B', pontos: 30 },
+      { jogadorId: 3, nome: 'C', pontos: '5' },
+      { jogadorId: 4, nome: 'D', pontos: '20' }
+    ];
+    service.getTopScorers(limit).subscribe((items: TopScorer[]) => {
+      expect(items.length).toBe(3);
+      expect(items).toEqual([
+        { jogadorId: 2, nome: 'B', pontos: 30 },
+        { jogadorId: 4, nome: 'D', pontos: 20 },
+        { jogadorId: 1, nome: 'A', pontos: 10 }
+      ]);
+      done();
+    });
+    const req = httpMock.expectOne(`${environment.apiUrl}/estatisticas/top-scorers/${limit}`);
+    expect(req.request.method).toBe('GET');
+    req.flush(apiMock);
+  });
+
+  it('getTopScorers deve propagar erro de HTTP', (done) => {
+    service.getTopScorers(5).subscribe({
+      next: () => fail('deveria falhar'),
+      error: () => {
+        done();
+      }
+    });
+    const req = httpMock.expectOne(`${environment.apiUrl}/estatisticas/top-scorers/5`);
+    expect(req.request.method).toBe('GET');
+    req.flush({ message: 'server error' }, { status: 500, statusText: 'Server Error' });
+  });
+});

--- a/src/app/core/services/jogo.service.spec.ts
+++ b/src/app/core/services/jogo.service.spec.ts
@@ -1,0 +1,106 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { JogoService, RegistrarResultadoConfrontoRequest, RegistrarResultadoConfrontoResponse } from './jogo.service';
+import { environment } from '../../../environments/environment';
+import { Jogo, MatchResult, MatchWinnerResult } from '../models/jogo.model';
+
+type JasmineExpectation = {
+  toBeTruthy: () => void;
+  toEqual: (expected: unknown) => void;
+  toBe: (expected: unknown) => void;
+};
+
+declare const describe: (name: string, fn: () => void) => void;
+declare const beforeEach: (fn: () => void | Promise<void>) => void;
+declare const afterEach: (fn: () => void | Promise<void>) => void;
+declare const it: (name: string, fn: (done: DoneFn) => void) => void;
+declare const expect: (actual: unknown) => JasmineExpectation;
+declare const fail: (message?: string) => void;
+interface DoneFn {
+  (): void;
+  fail: (message?: string | Error) => void;
+}
+
+describe('JogoService', () => {
+  let service: JogoService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
+    service = TestBed.inject(JogoService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('getJogos deve fazer GET para /jogo/all', (done) => {
+    const mock: Jogo[] = [{ id: 1, duracao: 10 }];
+    service.getJogos().subscribe((data) => {
+      expect(data).toEqual(mock);
+      done();
+    });
+    const req = httpMock.expectOne(`${environment.apiUrl}/jogo/all`);
+    expect(req.request.method).toBe('GET');
+    req.flush(mock);
+  });
+
+  it('getJogoById deve fazer GET para /jogo/:id e propagar erro', (done) => {
+    const id = 42;
+    service.getJogoById(id).subscribe({
+      next: () => fail('deveria falhar'),
+      error: () => {
+        done();
+      }
+    });
+    const req = httpMock.expectOne(`${environment.apiUrl}/jogo/${id}`);
+    expect(req.request.method).toBe('GET');
+    req.flush({ message: 'not found' }, { status: 404, statusText: 'Not Found' });
+  });
+
+  it('getJogoResultados deve fazer GET para /confrontos/:id/results', (done) => {
+    const id = 7;
+    const mock: MatchResult[] = [{ timeId: 1, pontuacao: 3, vencedor: false, idJogo: id }];
+    service.getJogoResultados(id).subscribe((data) => {
+      expect(data).toEqual(mock);
+      done();
+    });
+    const req = httpMock.expectOne(`${environment.apiUrl}/confrontos/${id}/results`);
+    expect(req.request.method).toBe('GET');
+    req.flush(mock);
+  });
+
+  it('getJogoWinner deve fazer GET para /confrontos/:id/winner', (done) => {
+    const id = 7;
+    const mock: MatchWinnerResult = {
+      jogoId: id,
+      empate: false,
+      vencedorTimeId: 2,
+      placares: [{ timeId: 2, pontos: 5 }]
+    };
+    service.getJogoWinner(id).subscribe((data) => {
+      expect(data).toEqual(mock);
+      done();
+    });
+    const req = httpMock.expectOne(`${environment.apiUrl}/confrontos/${id}/winner`);
+    expect(req.request.method).toBe('GET');
+    req.flush(mock);
+  });
+
+  it('registrarResultadoConfronto deve fazer POST para /confrontos/:id/result com body correto', (done) => {
+    const id = 9;
+    const payload: RegistrarResultadoConfrontoRequest = { timeId: 3, pontos: 2 };
+    const mock: RegistrarResultadoConfrontoResponse = { ok: true };
+    service.registrarResultadoConfronto(id, payload).subscribe((data) => {
+      expect(data).toEqual(mock);
+      done();
+    });
+    const req = httpMock.expectOne(`${environment.apiUrl}/confrontos/${id}/result`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(payload);
+    req.flush(mock);
+  });
+});


### PR DESCRIPTION
## O que mudou
- Novas specs com HttpTestingController para:
  - AuthService (login: sucesso/erro, método/URL/body)
  - JogoService (GETs/POST: método/URL/body, erro em getJogoById)
  - EstatisticasService (normalização, ordenação e limite, erro)

## Por que mudou
- src/app/core/services/auth.service.spec.ts: valida endpoint e body do login.
- src/app/core/services/jogo.service.spec.ts: garante contratos de URLs e métodos dos endpoints de jogo.
- src/app/core/services/estatisticas.service.spec.ts: garante normalização e ordenação dos dados recebidos.

## Contexto
Closes #18