### PR TITLE
test: Testes de Componentes (mocks)

### DIFF
--- a/src/app/features/auth/login/login.component.spec.ts
+++ b/src/app/features/auth/login/login.component.spec.ts
@@ -1,0 +1,116 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { Observable, of, throwError } from 'rxjs';
+import { AuthService, LoginResponse } from '../../../core/services/auth.service';
+import { LoginComponent } from './login.component';
+
+type JasmineExpectation = {
+  toBeTruthy: () => void;
+  toEqual: (expected: unknown) => void;
+  toBe: (expected: unknown) => void;
+};
+
+declare const describe: (name: string, fn: () => void) => void;
+declare const beforeEach: (fn: () => void | Promise<void>) => void;
+declare const afterEach: (fn: () => void | Promise<void>) => void;
+declare const it: (name: string, fn: () => void) => void;
+declare const expect: (actual: unknown) => JasmineExpectation;
+
+describe('LoginComponent', () => {
+  let loginResponse$: Observable<LoginResponse>;
+  let lastLoginPayload: unknown = null;
+  let setTokenValue: string | null = null;
+  let navigations: unknown[] = [];
+  let originalConsoleError: typeof console.error;
+
+  const authServiceMock: Pick<AuthService, 'login' | 'setToken'> = {
+    login: (credentials: { login: string; senha?: string }) => {
+      lastLoginPayload = credentials;
+      return loginResponse$;
+    },
+    setToken: (token: string) => {
+      setTokenValue = token;
+    }
+  };
+
+  beforeEach(async () => {
+    loginResponse$ = of({ access_token: 'token' });
+    lastLoginPayload = null;
+    setTokenValue = null;
+    navigations = [];
+    originalConsoleError = console.error;
+    console.error = ((..._args: unknown[]) => {}) as typeof console.error;
+
+    await TestBed.configureTestingModule({
+      imports: [LoginComponent],
+      providers: [provideRouter([]), { provide: AuthService, useValue: authServiceMock }]
+    }).compileComponents();
+
+    const router = TestBed.inject(Router);
+    router.navigate = ((commands: unknown[]) => {
+      navigations.push(commands);
+      return Promise.resolve(true);
+    }) as unknown as Router['navigate'];
+  });
+
+  afterEach(() => {
+    console.error = originalConsoleError;
+  });
+
+  it('deve criar o componente', () => {
+    const fixture = TestBed.createComponent(LoginComponent);
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('não deve submeter quando inválido e deve mostrar erros do formulário', () => {
+    const fixture = TestBed.createComponent(LoginComponent);
+    const component = fixture.componentInstance;
+
+    fixture.detectChanges();
+
+    component.loginForm.setValue({ login: '', senha: '' });
+    component.onSubmit();
+    fixture.detectChanges();
+
+    expect(lastLoginPayload).toBe(null);
+
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text.includes('Username is required.')).toBe(true);
+    expect(text.includes('Password is required.')).toBe(true);
+  });
+
+  it('deve fazer login, salvar token e navegar para /jogos quando válido', () => {
+    const fixture = TestBed.createComponent(LoginComponent);
+    const component = fixture.componentInstance;
+
+    fixture.detectChanges();
+
+    component.loginForm.setValue({ login: 'user', senha: 'pass' });
+    component.onSubmit();
+    fixture.detectChanges();
+
+    expect(lastLoginPayload).toEqual({ login: 'user', senha: 'pass' });
+    expect(setTokenValue).toBe('token');
+    expect(navigations.length).toBe(1);
+    expect(navigations[0]).toEqual(['/jogos']);
+  });
+
+  it('deve exibir mensagem de credenciais inválidas quando API retorna 401', () => {
+    loginResponse$ = throwError(() => ({ status: 401 }));
+
+    const fixture = TestBed.createComponent(LoginComponent);
+    const component = fixture.componentInstance;
+
+    fixture.detectChanges();
+
+    component.loginForm.setValue({ login: 'user', senha: 'bad' });
+    component.onSubmit();
+    fixture.detectChanges();
+
+    expect(component.isLoading).toBe(false);
+    expect(component.errorMessage).toBe('Credenciais inválidas. Verifique seu usuário e senha.');
+
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text.includes('Credenciais inválidas.')).toBe(true);
+  });
+});

--- a/src/app/features/jogos/criacao-jogo/criacao-jogo.component.spec.ts
+++ b/src/app/features/jogos/criacao-jogo/criacao-jogo.component.spec.ts
@@ -1,0 +1,128 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { Observable, of, throwError } from 'rxjs';
+import { JogoService } from '../../../core/services/jogo.service';
+import { Jogo } from '../../../core/models/jogo.model';
+import { CriacaoJogoComponent } from './criacao-jogo.component';
+
+type JasmineExpectation = {
+  toBeTruthy: () => void;
+  toEqual: (expected: unknown) => void;
+  toBe: (expected: unknown) => void;
+};
+
+declare const describe: (name: string, fn: () => void) => void;
+declare const beforeEach: (fn: () => void | Promise<void>) => void;
+declare const afterEach: (fn: () => void | Promise<void>) => void;
+declare const it: (name: string, fn: () => void) => void;
+declare const expect: (actual: unknown) => JasmineExpectation;
+
+describe('CriacaoJogoComponent', () => {
+  let criarResponse$: Observable<Jogo>;
+  let criarCalls = 0;
+  let lastPayload: unknown = null;
+  let navigations: unknown[] = [];
+  let originalConsoleError: typeof console.error;
+
+  const jogoServiceMock: Pick<JogoService, 'criarJogo'> = {
+    criarJogo: (payload: { duracao: number }) => {
+      criarCalls += 1;
+      lastPayload = payload;
+      return criarResponse$;
+    }
+  };
+
+  beforeEach(async () => {
+    criarResponse$ = of({ id: 10, duracao: 90 });
+    criarCalls = 0;
+    lastPayload = null;
+    navigations = [];
+    originalConsoleError = console.error;
+    console.error = ((..._args: unknown[]) => {}) as typeof console.error;
+
+    await TestBed.configureTestingModule({
+      imports: [CriacaoJogoComponent],
+      providers: [provideRouter([]), { provide: JogoService, useValue: jogoServiceMock }]
+    }).compileComponents();
+
+    const router = TestBed.inject(Router);
+    router.navigate = ((commands: unknown[]) => {
+      navigations.push(commands);
+      return Promise.resolve(true);
+    }) as unknown as Router['navigate'];
+  });
+
+  afterEach(() => {
+    console.error = originalConsoleError;
+  });
+
+  it('deve criar o componente', () => {
+    const fixture = TestBed.createComponent(CriacaoJogoComponent);
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('não deve submeter quando inválido e deve mostrar erro required', () => {
+    const fixture = TestBed.createComponent(CriacaoJogoComponent);
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    component.onSubmit();
+    fixture.detectChanges();
+
+    expect(criarCalls).toBe(0);
+    expect(lastPayload).toBe(null);
+
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text.includes('A duração é obrigatória.')).toBe(true);
+  });
+
+  it('não deve submeter quando duracao é menor que 1 e deve mostrar erro min', () => {
+    const fixture = TestBed.createComponent(CriacaoJogoComponent);
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    component.jogoForm.get('duracao')?.setValue(0);
+    component.onSubmit();
+    fixture.detectChanges();
+
+    expect(criarCalls).toBe(0);
+
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text.includes('Duração mínima de 1 minuto.')).toBe(true);
+  });
+
+  it('deve criar jogo e navegar para /jogos/:id quando válido', () => {
+    criarResponse$ = of({ id: 123, duracao: 90 });
+
+    const fixture = TestBed.createComponent(CriacaoJogoComponent);
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    component.jogoForm.get('duracao')?.setValue(90);
+    component.onSubmit();
+    fixture.detectChanges();
+
+    expect(criarCalls).toBe(1);
+    expect(lastPayload).toEqual({ duracao: 90 });
+    expect(navigations.length).toBe(1);
+    expect(navigations[0]).toEqual(['/jogos', 123]);
+  });
+
+  it('deve exibir mensagem de erro quando API falha', () => {
+    criarResponse$ = throwError(() => new Error('falha'));
+
+    const fixture = TestBed.createComponent(CriacaoJogoComponent);
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    component.jogoForm.get('duracao')?.setValue(90);
+    component.onSubmit();
+    fixture.detectChanges();
+
+    expect(component.isLoading).toBe(false);
+    expect(component.errorMessage).toBe('Erro ao criar jogo. Por favor, tente novamente.');
+
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text.includes('Erro ao criar jogo. Por favor, tente novamente.')).toBe(true);
+  });
+});

--- a/src/app/features/jogos/list-jogos/list-jogos.component.spec.ts
+++ b/src/app/features/jogos/list-jogos/list-jogos.component.spec.ts
@@ -1,0 +1,161 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { Observable, Subject, of, throwError } from 'rxjs';
+import { AuthService } from '../../../core/services/auth.service';
+import { JogoService } from '../../../core/services/jogo.service';
+import { RolesService } from '../../../core/services/roles.service';
+import { JogoComDetalhes, MatchResult } from '../../../core/models/jogo.model';
+import { ListJogosComponent } from './list-jogos.component';
+import { Role } from '../../../core/models/role.model';
+
+type JasmineExpectation = {
+  toBeTruthy: () => void;
+  toEqual: (expected: unknown) => void;
+  toBe: (expected: unknown) => void;
+};
+
+declare const describe: (name: string, fn: () => void) => void;
+declare const beforeEach: (fn: () => void | Promise<void>) => void;
+declare const afterEach: (fn: () => void | Promise<void>) => void;
+declare const it: (name: string, fn: () => void) => void;
+declare const expect: (actual: unknown) => JasmineExpectation;
+
+describe('ListJogosComponent', () => {
+  let jogos$: Observable<JogoComDetalhes[]>;
+  let resultadosByJogoId: (jogoId: number) => Observable<MatchResult[]>;
+  let getJogosCalls = 0;
+  let getResultadosCalls = 0;
+  let originalConsoleError: typeof console.error;
+
+  let tokenRoleResult: boolean | null = true;
+  let roles$: Observable<Role[]>;
+
+  const authServiceMock: Pick<AuthService, 'hasRoleFromToken'> = {
+    hasRoleFromToken: () => tokenRoleResult
+  };
+
+  const jogoServiceMock: Pick<JogoService, 'getJogos' | 'getJogoResultados'> = {
+    getJogos: () => {
+      getJogosCalls += 1;
+      return jogos$;
+    },
+    getJogoResultados: (jogoId: number) => {
+      getResultadosCalls += 1;
+      return resultadosByJogoId(jogoId);
+    }
+  };
+
+  const rolesServiceMock: Pick<RolesService, 'getRoles'> = {
+    getRoles: () => roles$
+  };
+
+  beforeEach(async () => {
+    jogos$ = of([]);
+    resultadosByJogoId = () => of([]);
+    roles$ = of([]);
+    tokenRoleResult = true;
+    getJogosCalls = 0;
+    getResultadosCalls = 0;
+    originalConsoleError = console.error;
+    console.error = ((..._args: unknown[]) => {}) as typeof console.error;
+
+    await TestBed.configureTestingModule({
+      imports: [ListJogosComponent],
+      providers: [
+        provideRouter([]),
+        { provide: AuthService, useValue: authServiceMock },
+        { provide: JogoService, useValue: jogoServiceMock },
+        { provide: RolesService, useValue: rolesServiceMock }
+      ]
+    }).compileComponents();
+  });
+
+  afterEach(() => {
+    console.error = originalConsoleError;
+  });
+
+  it('deve criar o componente', () => {
+    const fixture = TestBed.createComponent(ListJogosComponent);
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('deve renderizar estado de loading enquanto a lista de jogos não retorna', () => {
+    const subject = new Subject<JogoComDetalhes[]>();
+    jogos$ = subject.asObservable();
+
+    const fixture = TestBed.createComponent(ListJogosComponent);
+    fixture.detectChanges();
+
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text.includes('Carregando jogos...')).toBe(true);
+    expect(getJogosCalls).toBe(1);
+
+    subject.complete();
+  });
+
+  it('deve renderizar estado vazio quando não há jogos e usuário pode criar jogo', () => {
+    tokenRoleResult = true;
+    jogos$ = of([]);
+
+    const fixture = TestBed.createComponent(ListJogosComponent);
+    fixture.detectChanges();
+
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text.includes('Nenhum jogo encontrado')).toBe(true);
+    expect(text.includes('Comece criando o primeiro jogo da temporada!')).toBe(true);
+    expect(text.includes('Criar Jogo')).toBe(true);
+  });
+
+  it('deve renderizar estado de erro quando falha ao carregar jogos e permitir tentar novamente', () => {
+    tokenRoleResult = true;
+    jogos$ = throwError(() => new Error('falha'));
+
+    const fixture = TestBed.createComponent(ListJogosComponent);
+    fixture.detectChanges();
+
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text.includes('Falha ao carregar a lista de jogos.')).toBe(true);
+    expect(text.includes('Tentar novamente')).toBe(true);
+    expect(getJogosCalls).toBe(1);
+
+    jogos$ = of([]);
+    const retryButton = (fixture.nativeElement as HTMLElement).querySelector(
+      'app-alert button'
+    ) as HTMLButtonElement | null;
+    expect(Boolean(retryButton)).toBe(true);
+
+    retryButton?.click();
+    fixture.detectChanges();
+
+    expect(getJogosCalls).toBe(2);
+  });
+
+  it('deve renderizar estado de erro de resultados quando falha ao buscar resultados do jogo', () => {
+    tokenRoleResult = true;
+    jogos$ = of([{ id: 1, duracao: 10 }]);
+    resultadosByJogoId = () => throwError(() => new Error('falha resultados'));
+
+    const fixture = TestBed.createComponent(ListJogosComponent);
+    fixture.detectChanges();
+
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(getResultadosCalls).toBe(1);
+    expect(text.includes('Falha ao carregar resultados.')).toBe(true);
+    expect(text.includes('Recarregar')).toBe(true);
+  });
+
+  it('deve renderizar erro de permissão no admin gate quando RolesService falha com 403', () => {
+    tokenRoleResult = null;
+    jogos$ = of([]);
+    roles$ = throwError(
+      () => new HttpErrorResponse({ status: 403, statusText: 'Forbidden', url: '/roles' })
+    );
+
+    const fixture = TestBed.createComponent(ListJogosComponent);
+    fixture.detectChanges();
+
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text.includes('Sem permissão para criar jogos.')).toBe(true);
+  });
+});


### PR DESCRIPTION
## O que mudou
- Adiciona specs com mocks de services para LoginComponent, ListJogosComponent e CriacaoJogoComponent.
- Valida estados de loading/erro/vazio e validações de formulário (sem chamar API real).

## Como validar
- npm test -- --watch=false --browsers=ChromeHeadless

## Contexto
Closes #19